### PR TITLE
:bug:fix: s3 bucket dependency problem solve

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -37,6 +37,8 @@ locals {
 resource "aws_s3_bucket_policy" "example" {
   bucket = aws_s3_bucket.deploy_bucket.id
   policy = local.replaced_policy
+
+  depends_on = [aws_s3_bucket_acl.example]
 }
 
 resource "aws_s3_bucket_website_configuration" "website-config" {


### PR DESCRIPTION
s3 모듈을 생성할 때 depends_on을 걸어 s3_bucket_acl과 s3_bucket_policy간의 종속성 관계를 명확하게 함