### PR TITLE
feat: ACM & Route53 module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,4 +85,16 @@ module "cloudfront" {
   source         = "./modules/cloudfront"
   s3_domain_name = module.s3.domain_name
   s3_id          = module.s3.id
+  acm_arn        = module.route53.acm_arn
+}
+
+###############################################################
+## route53
+###############################################################
+
+module "route53" {
+  source             = "./modules/route53"
+  domain_name        = "kkamji.net"
+  cdn_domain_name    = module.cloudfront.domain_name
+  cdn_hosted_zone_id = module.cloudfront.hosted_zone_id
 }

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ module "cloudfront" {
 
 module "route53" {
   source             = "./modules/route53"
-  domain_name        = "rememberme.kkamji.net"
+  domain_name        = "kkamji.net"
   cdn_domain_name    = module.cloudfront.domain_name
   cdn_hosted_zone_id = module.cloudfront.hosted_zone_id
 }

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ module "cloudfront" {
 
 module "route53" {
   source             = "./modules/route53"
-  domain_name        = "kkamji.net"
+  domain_name        = "rememberme.kkamji.net"
   cdn_domain_name    = module.cloudfront.domain_name
   cdn_hosted_zone_id = module.cloudfront.hosted_zone_id
 }

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -1,15 +1,15 @@
-resource "aws_cloudfront_origin_access_identity" "cloudfront_oai" {
+resource "aws_cloudfront_origin_access_identity" "example" {
   comment = "cloudfront_origin_access_identity comment"
 }
 
-resource "aws_cloudfront_distribution" "s3_distribution" {
+resource "aws_cloudfront_distribution" "example" {
   origin {
     domain_name = var.s3_domain_name
     origin_id   = var.s3_id
 
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.cloudfront_oai.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.example.cloudfront_access_identity_path
     }
 
     origin_shield {
@@ -53,5 +53,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
   viewer_certificate {
     cloudfront_default_certificate = true
+    acm_certificate_arn            = var.acm_arn
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1"
   }
 }

--- a/modules/cloudfront/outputs.tf
+++ b/modules/cloudfront/outputs.tf
@@ -1,9 +1,14 @@
 output "cdn_arn" {
   description = "The ARN of the cloudfront."
-  value       = aws_cloudfront_distribution.s3_distribution.arn
+  value       = aws_cloudfront_distribution.example.arn
 }
 
 output "domain_name" {
   description = "The domain name for the cloudfront."
-  value       = aws_cloudfront_distribution.s3_distribution.domain_name
+  value       = aws_cloudfront_distribution.example.domain_name
+}
+
+output "hosted_zone_id" {
+  description = "The hosted zone id for the cloudfront."
+  value       = aws_cloudfront_distribution.example.hosted_zone_id
 }

--- a/modules/cloudfront/outputs.tf
+++ b/modules/cloudfront/outputs.tf
@@ -12,3 +12,8 @@ output "hosted_zone_id" {
   description = "The hosted zone id for the cloudfront."
   value       = aws_cloudfront_distribution.example.hosted_zone_id
 }
+
+output "distribution_id" {
+  description = "The ID of the cloudfront."
+  value       = aws_cloudfront_distribution.example.id
+}

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -7,3 +7,8 @@ variable "s3_id" {
   type        = string
   description = "Id of the S3"
 }
+
+variable "acm_arn" {
+  type        = string
+  description = "The ARN of the ACM"
+}

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -27,7 +27,7 @@ resource "aws_acm_certificate_validation" "cert" {
 
 resource "aws_route53_record" "this" {
   zone_id = data.aws_route53_zone.example.id
-  name    = var.domain_name
+  name    = "rememberme.${var.domain_name}"
 
   type = "A"
 

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,0 +1,39 @@
+data "aws_route53_zone" "example" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "example" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "example" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.example.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.example.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.example.domain_validation_options)[0].resource_record_type
+  zone_id         = data.aws_route53_zone.example.id
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.example.arn
+  validation_record_fqdns = [aws_route53_record.example.fqdn]
+}
+
+resource "aws_route53_record" "this" {
+  zone_id = data.aws_route53_zone.example.id
+  name    = var.domain_name
+
+  type = "A"
+
+  alias {
+    name                   = var.cdn_domain_name
+    zone_id                = var.cdn_hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -1,0 +1,3 @@
+output "acm_arn" {
+  value = aws_acm_certificate.example.arn
+}

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -1,3 +1,11 @@
 output "acm_arn" {
   value = aws_acm_certificate.example.arn
 }
+
+output "route53_alias" {
+  value = aws_route53_record.this.alias
+}
+
+output "route53_name" {
+  value = aws_route53_record.this.name
+}

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,0 +1,14 @@
+variable "domain_name" {
+  type        = string
+  description = "The domain name for the A record (e.g., www.example.com)."
+}
+
+variable "cdn_domain_name" {
+  type        = string
+  description = "The domain name for the cloudfront."
+}
+
+variable "cdn_hosted_zone_id" {
+  type        = string
+  description = "The hosted zone id for the cloudfront."
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,17 +1,17 @@
-resource "aws_s3_bucket" "deploy_bucket" {
+resource "aws_s3_bucket" "example" {
   bucket        = var.name
   force_destroy = true
 }
 
 resource "aws_s3_bucket_ownership_controls" "example" {
-  bucket = aws_s3_bucket.deploy_bucket.id
+  bucket = aws_s3_bucket.example.id
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
 }
 
 resource "aws_s3_bucket_public_access_block" "example" {
-  bucket = aws_s3_bucket.deploy_bucket.id
+  bucket = aws_s3_bucket.example.id
 
   block_public_acls       = false
   block_public_policy     = false
@@ -25,24 +25,24 @@ resource "aws_s3_bucket_acl" "example" {
     aws_s3_bucket_public_access_block.example,
   ]
 
-  bucket = aws_s3_bucket.deploy_bucket.id
+  bucket = aws_s3_bucket.example.id
   acl    = "public-read"
 }
 
 locals {
   policy_content  = file(var.policy_file)
-  replaced_policy = replace(local.policy_content, "BUCKET_ARN", aws_s3_bucket.deploy_bucket.arn)
+  replaced_policy = replace(local.policy_content, "BUCKET_ARN", aws_s3_bucket.example.arn)
 }
 
 resource "aws_s3_bucket_policy" "example" {
-  bucket = aws_s3_bucket.deploy_bucket.id
+  bucket = aws_s3_bucket.example.id
   policy = local.replaced_policy
 
   depends_on = [aws_s3_bucket_acl.example]
 }
 
-resource "aws_s3_bucket_website_configuration" "website-config" {
-  bucket = aws_s3_bucket.deploy_bucket.id
+resource "aws_s3_bucket_website_configuration" "example" {
+  bucket = aws_s3_bucket.example.id
   index_document {
     suffix = "index.html"
   }

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,24 +1,24 @@
 output "bucket_name" {
   description = "The name of the S3 bucket."
-  value       = aws_s3_bucket.deploy_bucket.bucket
+  value       = aws_s3_bucket.example.bucket
 }
 
 output "bucket_arn" {
   description = "The ARN of the S3 bucket."
-  value       = aws_s3_bucket.deploy_bucket.arn
+  value       = aws_s3_bucket.example.arn
 }
 
 output "website_endpoint" {
   description = "The website endpoint for the S3 bucket."
-  value       = aws_s3_bucket_website_configuration.website-config.website_endpoint
+  value       = aws_s3_bucket_website_configuration.example.website_endpoint
 }
 
 output "id" {
   description = "The Id of the S3 bucket."
-  value       = aws_s3_bucket.deploy_bucket.id
+  value       = aws_s3_bucket.example.id
 }
 
 output "domain_name" {
   description = "The Domain name of the S3 bucket."
-  value       = aws_s3_bucket.deploy_bucket.bucket_domain_name
+  value       = aws_s3_bucket.example.bucket_domain_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,3 +69,19 @@ output "cdn_arn" {
 output "domain_name" {
   value = module.cloudfront.domain_name
 }
+
+###############################################################
+## route53
+###############################################################
+
+output "acm_arn" {
+  value = module.route53.acm_arn
+}
+
+output "route53_alias" {
+  value = module.route53.route53_alias
+}
+
+output "route53_name" {
+  value = module.route53.route53_name
+}


### PR DESCRIPTION
S3 정적 웹 호스팅 앞단에 붙는 cloudfront의 SSL/TLS 통신을 위해 ACM을 생성하고 Route53에 붙여서 원하는 도메인으로 호출할 수 있게끔 한다.