### PR TITLE
feat: WAF

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 ###############################################################
 ## iam_group_membership
 ###############################################################
@@ -94,7 +99,7 @@ module "cloudfront" {
 
 module "route53" {
   source             = "./modules/route53"
-  domain_name        = "kkamji.net"
+  domain_name        = "*.kkamji.net"
   cdn_domain_name    = module.cloudfront.domain_name
   cdn_hosted_zone_id = module.cloudfront.hosted_zone_id
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -4,6 +4,7 @@ data "aws_route53_zone" "example" {
 }
 
 resource "aws_acm_certificate" "example" {
+  provider          = aws.us-east-1
   domain_name       = var.domain_name
   validation_method = "DNS"
   lifecycle {
@@ -21,6 +22,7 @@ resource "aws_route53_record" "example" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
+  provider                = aws.us-east-1
   certificate_arn         = aws_acm_certificate.example.arn
   validation_record_fqdns = [aws_route53_record.example.fqdn]
 }

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -1,0 +1,42 @@
+resource "aws_wafv2_web_acl" "example" {
+  name  = "rate-based-example"
+  scope = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 10000
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL", "KR"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "overrated metrics"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "metrics"
+    sampled_requests_enabled   = false
+  }
+}


### PR DESCRIPTION
Cloudfront 접근을 할 때 보안을 위해 WAF를 만들었습니다.

지금 ACM을 버지니아리전에서 받아와야하는데 받아오지 못해 provider로 리전을 추가하였습니다. 하지만, 로컬에서 validate와 Plan을 돌렸을 때, 자꾸 에러가 나서 이 부분 해결되야 할 것 같습니다.
에러 공론화(?) 공식화(?)를 위해서 PR을 열었습니다.
해결 방법을 찾는다면 코멘트로 남겨주시면 감사하겠습니다.

Resolve: #40