### PR TITLE
fix: change route53 provider using provider alias

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
 ###############################################################
 ## iam_group_membership
 ###############################################################
@@ -83,7 +88,7 @@ module "cloudfront" {
   s3_id          = module.s3.id
   acm_arn        = module.route53.acm_arn
 }
-    
+
 module "parameter_store_cloudfront_distribution_id" {
   source = "./modules/aws_ssm_parameter"
   name   = "/remember-me/cloudfront-distribution-id"
@@ -100,4 +105,8 @@ module "route53" {
   domain_name        = "kkamji.net"
   cdn_domain_name    = module.cloudfront.domain_name
   cdn_hosted_zone_id = module.cloudfront.hosted_zone_id
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.75"
+    }
+  }
+}
+
 data "aws_route53_zone" "example" {
   name         = var.domain_name
   private_zone = false


### PR DESCRIPTION
provider alias를 사용해 acm 인증서를 생성하는 route53 모듈이 us-east-1 리전을 사용하도록 명시.

```bash
│ Warning: Reference to undefined provider
│ 
│   on main.tf line 45, in module "route53":
│   45:     aws = aws.us_east_1
│ 
│ There is no explicit declaration for local provider name "aws" in module.route53, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".
│ 
│ If you also control the child module, add a required_providers entry named "aws" with the source address "hashicorp/aws".
```

위의 경고를 피하기 위해 route53 모듈에 terraform provider의 spec을 명시하는 부분 추가