### PR TITLE
fix: lambda layer removed

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -5,6 +5,10 @@ resource "aws_lambda_function" "this" {
   layers        = var.layer_arns
   handler       = "${var.function_name}.handler"
   runtime       = var.runtime
+  
+  lifecycle {
+    ignore_changes = [layers]
+  }
 }
 
 resource "aws_lambda_permission" "this" {


### PR DESCRIPTION
lambda module에서 lifecycle을 추가해 terraform apply를 할때마다 layer가 사라지는 것을 방지