### PR TITLE
feat: cloudwatch log group and cloudwatch log subscription filter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -234,103 +234,113 @@ module "lambda_subscription_filter" {
 }
 
 module "lambda_get_test" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "test"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "test"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_get_user" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "getUser"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "getUser"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_get_lists" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "getLists"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "getLists"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_list" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postList"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postList"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_words" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postWords"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postWords"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_word" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postWord"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postWord"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_get_incorrect_lists" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "getIncorrectLists"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "getIncorrectLists"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_incorrect_list" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postIncorrectList"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postIncorrectList"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_incorrect_words" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postIncorrectWords"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postIncorrectWords"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 module "lambda_post_incorrect_word" {
-  source                         = "./modules/lambda"
-  role_arn                       = module.lambda_iam_role.arn
-  filename                       = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
-  function_name                  = "postIncorrectWord"
-  runtime                        = "nodejs20.x"
-  lambda_permission_statement_id = "AllowAPIGatewayInvoke"
-  lambda_permission_source_arn   = "${module.api_gateway.execution_arn}/*/*"
+  source                                  = "./modules/lambda"
+  role_arn                                = module.lambda_iam_role.arn
+  filename                                = "${path.module}/templates/lambda/lambda_nodejs_code.zip"
+  function_name                           = "postIncorrectWord"
+  runtime                                 = "nodejs20.x"
+  lambda_permission_statement_id          = "AllowAPIGatewayInvoke"
+  lambda_permission_source_arn            = "${module.api_gateway.execution_arn}/*/*"
+  log_subscription_filter_destination_arn = module.lambda_subscription_filter.arn
 }
 
 ###############################################################

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "this" {
   layers        = var.layer_arns
   handler       = "${var.function_name}.handler"
   runtime       = var.runtime
-  
+
   lifecycle {
     ignore_changes = [layers]
   }
@@ -17,4 +17,16 @@ resource "aws_lambda_permission" "this" {
   function_name = aws_lambda_function.this.function_name
   principal     = var.lambda_permission_principal
   source_arn    = var.lambda_permission_source_arn
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "this" {
+  name            = "${var.function_name}-subscription"
+  log_group_name  = aws_cloudwatch_log_group.this.name
+  filter_pattern  = var.log_subscription_filter_pattern
+  destination_arn = var.log_subscription_filter_destination_arn
 }

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -51,3 +51,21 @@ variable "lambda_permission_source_arn" {
   type        = string
   description = "Source ARN of the lambda permission"
 }
+
+variable "log_retention_days" {
+  type        = number
+  description = "Number of days to retain the lambda function's logs 0, 1, 3, 5, 7, 14, 30 ..."
+  default     = 14
+}
+
+variable "log_subscription_filter_pattern" {
+  type        = string
+  description = "Filter pattern for the lambda function's log group"
+  default     = ""
+}
+
+variable "log_subscription_filter_destination_arn" {
+  type        = string
+  description = "Destination ARN for the filtered logs"
+  default     = ""
+}


### PR DESCRIPTION
- lambda module에 `aws_cloudwatch_log_group` 리소스를 추가해 lambda function의 로그가 저장될 log group을 명시적으로 생성
- lambda module에 `aws_cloudwatch_log_subscription_filter` 리소스를 추가해 log group의 subscription filter를 지정할 수 있도록 변경