### PR TITLE
:pencil:chore: update lambda environment and lifecycle

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -5,9 +5,12 @@ resource "aws_lambda_function" "this" {
   layers        = var.layer_arns
   handler       = "${var.function_name}.handler"
   runtime       = var.runtime
+  environment {
+    variables = var.environment_variables
+  }
 
   lifecycle {
-    ignore_changes = [layers]
+    ignore_changes = [layers, environment]
   }
 }
 

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -24,6 +24,12 @@ variable "runtime" {
   description = "Runtime of the lambda function"
 }
 
+variable "environment_variables" {
+  type        = map(string)
+  description = "Environment variables for the lambda function"
+  default     = {}
+}
+
 variable "handler" {
   type        = string
   description = "Handler of the lambda function"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b31dc182-ac94-4eb6-99d5-3af00d91305e)

GitHub Actions CI/CD를 통해 수동으로 lambda function의 `environment`를 주입하니 다음 terraform apply를 할 때 tfstate 차이가 발생해 사진과 같이 환경변수를 삭제함. lambda module에서 `environment`를 명시적으로 추가한 뒤, `lifecycle`의 `ignore_changed`에 `environment` 추가