### PR TITLE
test: budget alarm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -400,9 +400,40 @@ module "budget_alarms" {
   account_name         = "Prod"
   account_budget_limit = 20
   policy_file          = "${path.module}/templates/sns-topic-policy.json"
+  cost_filter_name     = "Service"
   services = {
-    S3 = {
-      budget_limit = 5.25
+    CloudWatch = {
+      budget_limit = 3.00
+    }
+  }
+  notifications = {
+    warning = {
+      comparison_operator = "GREATER_THAN"
+      threshold           = 100
+      threshold_type      = "PERCENTAGE"
+      notification_type   = "ACTUAL"
+    }
+  }
+}
+
+module "budget_alarms_invoice" {
+  source               = "./modules/budgets"
+  account_name         = "Prod"
+  account_budget_limit = 20
+  policy_file          = "${path.module}/templates/sns-topic-policy.json"
+  cost_filter_name     = "InvoicingEntity"
+  services = {
+    TOTALINVOICE = {
+      budget_limit = 12.00
+    },
+    TOTALINVOICE = {
+      budget_limit = 13.00
+    },
+    TOTALINVOICE = {
+      budget_limit = 14.00
+    },
+    TOTALINVOICE = {
+      budget_limit = 15.00
     }
   }
   notifications = {
@@ -425,6 +456,15 @@ module "chatbot" {
   slack_channel_id   = "C080E1FQ76H"
   slack_team_id      = "T08040UPUG6"
   sns_topic_arns     = module.budget_alarms.budget_alarms_sns_topic_arn
+}
+
+module "invoice_chatbot" {
+  source             = "./modules/chatbot"
+  configuration_name = "aws-invoice-budget"
+  iam_role_arn       = module.chatbot_iam_role.arn
+  slack_channel_id   = "C080E1FQ76H"
+  slack_team_id      = "T08040UPUG6"
+  sns_topic_arns     = module.budget_alarms_invoice.budget_alarms_sns_topic_arn
 }
 
 module "waf_chatbot" {

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -50,7 +50,7 @@ resource "aws_budgets_budget" "budget_resources" {
   time_period_start = "2024-11-12_00:00"
 
   cost_filter {
-    name = "Service"
+    name = var.cost_filter_name
     values = [
       lookup(local.aws_services, each.key)
     ]

--- a/modules/budgets/services.tf
+++ b/modules/budgets/services.tf
@@ -41,5 +41,6 @@ locals {
     VPC            = "Amazon Virtual Private Cloud"
     WAF            = "AWS WAF"
     XRay           = "AWS X-Ray"
+    TOTALINVOICE   = "Amazon Web Services, Inc."
   }
 }

--- a/modules/budgets/variables.tf
+++ b/modules/budgets/variables.tf
@@ -20,6 +20,11 @@ variable "budget_time_unit" {
   default     = "MONTHLY"
 }
 
+variable "cost_filter_name" {
+  description = "The name of cost filter"
+  type        = string
+}
+
 variable "services" {
   description = "Define the list of services and their limit of budget."
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,3 +92,7 @@ output "route53_name" {
 output "budgets_topic_arn" {
   value = module.budget_alarms.budget_alarms_sns_topic_arn
 }
+
+output "invoice_budgets_topic_arn" {
+  value = module.budget_alarms_invoice.budget_alarms_sns_topic_arn
+}


### PR DESCRIPTION
CloudWatch 3달러, 통합 결제비용은 12,13,14,15달러에 알람이 울리도록 설정합니다.

Related to: #99 