### PR TITLE
fix: budget alarm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -418,7 +418,7 @@ module "budget_alarms" {
 
 module "budget_alarms_invoice" {
   source               = "./modules/budgets"
-  account_name         = "Prod"
+  account_name         = "Invoice"
   account_budget_limit = 20
   policy_file          = "${path.module}/templates/sns-topic-policy.json"
   cost_filter_name     = "InvoicingEntity"
@@ -462,7 +462,7 @@ module "invoice_chatbot" {
   source             = "./modules/chatbot"
   configuration_name = "aws-invoice-budget"
   iam_role_arn       = module.chatbot_iam_role.arn
-  slack_channel_id   = "C080E1FQ76H"
+  slack_channel_id   = "C082C5SDD2Q"
   slack_team_id      = "T08040UPUG6"
   sns_topic_arns     = module.budget_alarms_invoice.budget_alarms_sns_topic_arn
 }


### PR DESCRIPTION
동일한 이름 사용과 채널 사용으로 충돌이 일어나서 이름을 수정하였고 slack 채널은 invoice용으로 하나 더 생성하였습니다.

Related to: #99