### PR TITLE
fix: budget alarm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -405,7 +405,7 @@ module "budget_alarms" {
   source               = "./modules/budgets"
   account_name         = "Prod"
   account_budget_limit = ["12", "13", "14", "15"]
-  policy_file          = "${path.module}/templates/sns-topic-policy.json"
+  policy_file          = "${path.module}/templates/sns-topic-policy-budget.json"
   cost_filter_name     = "Service"
   services = {
     CloudWatch = {
@@ -419,6 +419,10 @@ module "budget_alarms" {
       threshold_type      = "PERCENTAGE"
       notification_type   = "ACTUAL"
     }
+  }
+
+  providers = {
+    aws = aws.us_east_1
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -420,10 +420,6 @@ module "budget_alarms" {
       notification_type   = "ACTUAL"
     }
   }
-
-  providers = {
-    aws = aws.us_east_1
-  }
 }
 
 ###############################################################

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_sns_topic" "account_billing_alarm_topic" {
-  name = "account-billing-alarm-topic"
+  name = "account-billing-alarm"
 }
 
 resource "aws_sns_topic_policy" "account_billing_alarm_policy" {

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.75"
+    }
+  }
+}
+
 resource "aws_sns_topic" "account_billing_alarm_topic" {
   name = "account-billing-alarm-topic"
 }

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_sns_topic" "account_billing_alarm_topic" {
-  name = "account-billing-alarm"
+  name = "account-billing-alarm-topic"
 }
 
 resource "aws_sns_topic_policy" "account_billing_alarm_policy" {

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -1,14 +1,3 @@
-terraform {
-  required_version = ">= 1.9.8"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.75"
-    }
-  }
-}
-
 resource "aws_sns_topic" "account_billing_alarm_topic" {
   name = "account-billing-alarm-topic"
 }

--- a/modules/budgets/main.tf
+++ b/modules/budgets/main.tf
@@ -16,6 +16,10 @@ resource "aws_sns_topic" "account_billing_alarm_topic" {
 resource "aws_sns_topic_policy" "account_billing_alarm_policy" {
   arn    = aws_sns_topic.account_billing_alarm_topic.arn
   policy = local.replaced_policy
+
+  depends_on = [
+    aws_sns_topic.account_billing_alarm_topic
+  ]
 }
 
 locals {

--- a/templates/sns-topic-policy-budget.json
+++ b/templates/sns-topic-policy-budget.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowAllAWSPublishActions",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "budgets.amazonaws.com"
+        },
+        "Action": "SNS:Publish",
+        "Resource": "TOPIC_ARN"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
SNS가 날라가지 않는 문제가 발생하였습니다. 현 커밋에서 수행한 수정 사항들을 정리해보자면,
1. 정책 재수정
2. chatbot과 budget이 global인 반면에 sns가 ap-northeast-2인점이 마음에 걸려, ap-northeast-1 으로 수정하여 WAF SNS와 동일한 리전에서 관리할 수 있도록 수정
  로컬에서 plan을 돌릴 때는 아무 문제가 없었지만, 테라폼 클라우드에서 자꾸 plan을 돌릴 때 에러가 발생하여 리전 수정은 취소하였습니다.
---
추후 고쳐지지 않고, 구독이 계속 분리되어 있다면 구독 리소스를 추가해서 붙여볼 예정입니다.

Related to: #111