### PR TITLE
fix: update budget chatbot policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,12 @@ module "chatbot_iam_policy" {
   policy_file = "${path.module}/templates/chatbot-policy.json"
 }
 
+module "chatbot_budget_iam_policy" {
+  source      = "./modules/iam_policy"
+  name        = "chatbot-budget-policy"
+  policy_file = "${path.module}/templates/chatbot-budget-policy.json"
+}
+
 ###############################################################
 ## iam_role
 ###############################################################
@@ -62,6 +68,12 @@ module "lambda_iam_role" {
 module "chatbot_iam_role" {
   source      = "./modules/iam_role"
   name        = "chatbot-role"
+  policy_file = "${path.module}/templates/chatbot-assume-role-policy.json"
+}
+
+module "chatbot_budget_iam_role" {
+  source      = "./modules/iam_role"
+  name        = "chatbot-budget-role"
   policy_file = "${path.module}/templates/chatbot-assume-role-policy.json"
 }
 
@@ -428,7 +440,7 @@ module "budget_alarms" {
 module "chatbot" {
   source             = "./modules/chatbot"
   configuration_name = "aws-budget"
-  iam_role_arn       = module.chatbot_iam_role.arn
+  iam_role_arn       = module.chatbot_budget_iam_role.arn
   slack_channel_id   = "C080E1FQ76H"
   slack_team_id      = "T08040UPUG6"
   sns_topic_arns     = module.budget_alarms.budget_alarms_sns_topic_arn

--- a/templates/chatbot-budget-policy.json
+++ b/templates/chatbot-budget-policy.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "budgets:ViewBudget",
+        "budgets:ModifyBudget",
+        "budgets:DescribeBudget"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish",
+        "sns:Subscribe"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
기존 policy는 cloudwatch와 연결이 되어있어서 budget을 제대로 가져오지 못할 것 같아서 budget을 조회할 수 있는 정책으로 수정하였습니다.

Related to: #111