### PR TITLE
fix: update waf rule

### DIFF
--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -68,9 +68,9 @@ resource "aws_wafv2_web_acl" "example" {
 
     statement {
       rate_based_statement {
-        limit              = 100
-        aggregate_key_type = "IP"
-
+        limit                 = 300
+        aggregate_key_type    = "IP"
+        evaluation_window_sec = 60
         scope_down_statement {
           geo_match_statement {
             country_codes = ["US", "NL", "KR"]


### PR DESCRIPTION
waf rule을 통해 30초에 100회 이상 요청을 한 유저를 block 하려고 했으나 300초에 100회 이상 요청을 한 유저를 block 하는 rule로 적용이 되어있었습니다. 

공식 문서를 찾아보니 `evaluation_window_sec`의 값은 1,2,5,10분 단위로 설정할 수 있었고, 1분에 300회 이상 요청을 보낸 IP를 block 하도록 수정했습니다.